### PR TITLE
Make checking for enabled lints buffer-local

### DIFF
--- a/autoload/lightline/lsp.vim
+++ b/autoload/lightline/lsp.vim
@@ -79,7 +79,7 @@ endfunction
 
 " lint status
 function! s:lint_enabled() abort
-  return get(g:, 'lsp_diagnostics_enabled', 0)
+  return get(g:, 'lsp_diagnostics_enabled', 0) && !empty(lsp#get_allowed_servers())
 endfunction
 
 " diagnostics current status


### PR DESCRIPTION
# Pull Request detail

## Related issues or PRs/関連issueやPR

None.

## Fix or Add/Remove in this PR/このプルリクエストでやったこと

- When assume the lint is enabled, now it requires that one language server needs to be enabled for the current buffer at least. 

## Do not fix or add/remove this PR/このプルリクエストでやらなかったこと

None.

## Pros and Cons/メリットとデメリット

- Pros: We can distinguish whether the current lint result is generated by some diagnostic executions or is just an empty due to no diagnostic executions.
- Cons: Maybe add a little bit overhead to indicators.

## Test/動作確認

Test item list up with checkbox, checked after tested./チェックボックス式にし、確認後チェックする。

- [x] Indicators don't output anything only if no language server is registered for the filetype of the current buffer.